### PR TITLE
bugfix:no statustext while tracking

### DIFF
--- a/frontend/src/hooks/useTimeTracking.jsx
+++ b/frontend/src/hooks/useTimeTracking.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 
 const useTimeTracking = (user) => {
   const [isTracking, setIsTracking] = useState(false);
+  const [statusText, setStatusText] = useState("Starte die Zeit");
 
   const startTracking = async () => {
     try {
@@ -15,6 +16,9 @@ const useTimeTracking = (user) => {
       if (response.status === 201) {
         setIsTracking(true);
         sessionStorage.setItem("timeTrackingToken", new Date().toISOString());
+        setStatusText(
+          "Deine Zeiterfassung läuft aktuell..Stoppe deine Zeit, wenn du fertig bist"
+        );
       } else {
         console.error(`Error starting time tracking: ${response.data}`);
       }
@@ -40,6 +44,9 @@ const useTimeTracking = (user) => {
 
       setIsTracking(false);
       sessionStorage.removeItem("timeTrackingToken");
+      setStatusText(
+        "Deine Zeiterfassung wurde beendet und eine Email wurde an das Personalbüro versendet"
+      );
     } catch (error) {
       console.error("Error stopping time tracking:", error.message);
     }
@@ -50,10 +57,13 @@ const useTimeTracking = (user) => {
 
     if (timeTrackingToken) {
       setIsTracking(true);
+      setStatusText(
+        "Deine Zeiterfassung läuft aktuell..Stoppe deine Zeit, wenn du fertig bist"
+      );
     }
   }, []);
 
-  return { isTracking, startTracking, stopTracking };
+  return { isTracking, startTracking, stopTracking, statusText };
 };
 
 export default useTimeTracking;

--- a/frontend/src/timeTracking/StartStopTracker.jsx
+++ b/frontend/src/timeTracking/StartStopTracker.jsx
@@ -2,16 +2,20 @@ import { FaPlayCircle, FaStop } from "react-icons/fa";
 import useTimeTracking from "../hooks/useTimeTracking";
 
 export default function StartStopTracker({ user }) {
-  const { isTracking, startTracking, stopTracking } = useTimeTracking(user);
+  const { isTracking, startTracking, stopTracking, statusText } =
+    useTimeTracking(user);
 
   return (
-    <div className="flex flex-row gap-12 justify-center items-center">
-      <button onClick={startTracking} disabled={isTracking}>
-        <FaPlayCircle />
-      </button>
-      <button onClick={stopTracking} disabled={!isTracking}>
-        <FaStop />
-      </button>
-    </div>
+    <>
+      <div className="flex flex-row gap-12 justify-center items-center mb-16">
+        <button onClick={startTracking} disabled={isTracking}>
+          <FaPlayCircle />
+        </button>
+        <button onClick={stopTracking} disabled={!isTracking}>
+          <FaStop />
+        </button>
+      </div>
+      <p className="text-4xl">{statusText}</p>
+    </>
   );
 }


### PR DESCRIPTION
**Kein Statustext, während der Zeiterfassung**

- Der User hatte kein Feedback, ob eine Zeiterfassung bereits gestartet wurde
- Nun wurde ein Statustext in der useTimeTracking Hook wie folgt hinzugefügt

1. Wenn die Zeiterfassung gestartet wurde
2. Wenn die Zeiterfassung aktuell läuft (auch nach Neuladen der Seite, da hier das Token im Sessionstorage als Grundlage dient)
3. Wenn die Zeiterfassung beendet wurde