### PR TITLE
feat: added styling to tracker page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Zeiterfassung App</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Popup.jsx
+++ b/frontend/src/components/Popup.jsx
@@ -33,7 +33,7 @@ export default function Popup({ errorDescription, messageType, title }) {
           <strong className="block font-medium text-2xl text-gray-900">
             {messageType === "error"
               ? `${title} fehlgeschlagen`
-              : `${title} erfolgreich`}
+              : `${title} erfolgreich abgeschlossen`}
           </strong>
 
           <p className="mt-1 text-2xl text-gray-700">{errorDescription}</p>

--- a/frontend/src/components/ui/buttons/TrackerButton.jsx
+++ b/frontend/src/components/ui/buttons/TrackerButton.jsx
@@ -1,15 +1,40 @@
+import { useEffect, useState } from "react";
 import { FaPlayCircle, FaStop } from "react-icons/fa";
+import { AiOutlineLoading3Quarters } from "react-icons/ai";
 
 export default function TrackerButton({ type, label, onClick, disabled }) {
+  const [buttonName, setButtonName] = useState(label);
+  useEffect(() => {
+    if (disabled === false && label === "Start") {
+      setButtonName("Start");
+    } else if (disabled === true && label === "Start") {
+      setButtonName("Zeiterfassung läuft");
+    } else {
+      setButtonName(label);
+    }
+  }, [disabled, label]);
+
   return (
     <button
       type={type}
-      className="px-10 py-6 text-3xl font-medium gap-6 inline-flex items-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+      className={`px-10 py-6 text-3xl font-medium gap-6 inline-flex items-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300  dark:focus:ring-blue-800 ${
+        disabled
+          ? "dark:bg-blue-400 dark:hover:bg-blue-500"
+          : "dark:bg-blue-600 dark:hover:bg-blue-700"
+      }`}
       disabled={disabled}
       onClick={onClick}
     >
-      {label}
-      {label === "Start" ? <FaPlayCircle /> : <FaStop />}
+      {buttonName}
+      {label === "Start" ? (
+        disabled ? (
+          <AiOutlineLoading3Quarters className="animate-spin" />
+        ) : (
+          <FaPlayCircle />
+        )
+      ) : (
+        <FaStop />
+      )}
     </button>
   );
 }

--- a/frontend/src/hooks/useTimeTracking.jsx
+++ b/frontend/src/hooks/useTimeTracking.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
-
+import { formatTime } from "../utils/formatDate";
 const useTimeTracking = (user) => {
   const [isTracking, setIsTracking] = useState(false);
   const [statusText, setStatusText] = useState("Starte die Zeit");
+  const [documentTitle, setDocumentTitle] = useState(document.title);
+  const [prevDocumentTitle] = useState(documentTitle);
 
   const startTracking = async () => {
     try {
@@ -16,8 +18,16 @@ const useTimeTracking = (user) => {
       if (response.status === 201) {
         setIsTracking(true);
         sessionStorage.setItem("timeTrackingToken", new Date().toISOString());
+
         setStatusText(
           "Deine Zeiterfassung läuft aktuell..Stoppe deine Zeit, wenn du fertig bist"
+        );
+        const timeTrackingToken = sessionStorage.getItem("timeTrackingToken");
+
+        setDocumentTitle(
+          (document.title = `Zeit läuft seit: ${formatTime(
+            new Date(timeTrackingToken)
+          )}`)
         );
       } else {
         console.error(`Error starting time tracking: ${response.data}`);
@@ -44,6 +54,7 @@ const useTimeTracking = (user) => {
 
       setIsTracking(false);
       sessionStorage.removeItem("timeTrackingToken");
+      setDocumentTitle((document.title = prevDocumentTitle));
       setStatusText(
         "Deine Zeiterfassung wurde beendet und eine Email wurde an das Personalbüro versendet"
       );
@@ -57,12 +68,16 @@ const useTimeTracking = (user) => {
 
     if (timeTrackingToken) {
       setIsTracking(true);
+
       setStatusText(
         "Deine Zeiterfassung läuft aktuell..Stoppe deine Zeit, wenn du fertig bist"
       );
     }
   }, []);
-
+  useEffect(() => {
+    if (documentTitle) {
+    }
+  }, [documentTitle]);
   return { isTracking, startTracking, stopTracking, statusText };
 };
 

--- a/frontend/src/timeTracking/StartStopTracker.jsx
+++ b/frontend/src/timeTracking/StartStopTracker.jsx
@@ -1,24 +1,35 @@
 import useTimeTracking from "../hooks/useTimeTracking";
 import TrackerButton from "../components/ui/buttons/TrackerButton";
-
+import Popup from "../components/Popup";
+import { formatDate, formatTime } from "../utils/formatDate";
 export default function StartStopTracker({ user }) {
   const { isTracking, startTracking, stopTracking, statusText } =
     useTimeTracking(user);
-
+  const timeTrackingToken = sessionStorage.getItem("timeTrackingToken");
+  const startedTime = formatTime(new Date(timeTrackingToken));
+  const startedDate = formatDate(new Date(timeTrackingToken));
   return (
-    <div className="flex flex-row gap-12 justify-center items-center">
-      <TrackerButton
-        type={"submit"}
-        label={"Start"}
-        onClick={startTracking}
-        disabled={isTracking}
-      />
-      <TrackerButton
-        type={"submit"}
-        label={"Stop"}
-        onClick={stopTracking}
-        disabled={!isTracking}
-      />
-    </div>
+    <section className="flex flex-col gap-12 mt-12">
+      <div className="flex flex-row gap-12 justify-center items-center">
+        <TrackerButton
+          type={"submit"}
+          label={"Start"}
+          onClick={startTracking}
+          disabled={isTracking}
+        />
+        <TrackerButton
+          type={"submit"}
+          label={"Stop"}
+          onClick={stopTracking}
+          disabled={!isTracking}
+        />
+      </div>
+      <p className="text-4xl">{statusText}</p>
+      {timeTrackingToken && (
+        <p>
+          Deine Zeit läuft seit: {startedTime}Uhr, den {startedDate}
+        </p>
+      )}
+    </section>
   );
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      "/api": { target: "http://localhost:3001" },
+      "/api": { target: "http://127.0.0.1:3001" },
     },
   },
 });


### PR DESCRIPTION
**Styling der Zeiterfassungs Page**

- Dynamische Start und Stop Buttons hinzugefügt. Beim Starten der Zeiterfassung wird ein Ladebutton angezeigt, statt des Start Buttons und ist disabled.
- Statustext provisorisch hinzugefügt mit der Info, wann die Session gestartet wurde. Die Information wird im Sessionstorage gespeichert.
- Webseiten Titel wird während der Zeiterfassung in die Startzeit ausgetauscht für bessere UX
